### PR TITLE
Use @loader_path instead of @rpath

### DIFF
--- a/Connection.xcodeproj/project.pbxproj
+++ b/Connection.xcodeproj/project.pbxproj
@@ -1983,7 +1983,7 @@
 				GCC_PREFIX_HEADER = ConnectionKit/Connection_Prefix.pch;
 				HEADER_SEARCH_PATHS = "\"$(SOURCE_ROOT)/CURLHandle/SFTP/libssh2/include\"";
 				INFOPLIST_FILE = "Resources/Framework-Info.plist";
-				INSTALL_PATH = "@rpath";
+				INSTALL_PATH = "@loader_path/../Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2023,7 +2023,7 @@
 				GCC_PREFIX_HEADER = ConnectionKit/Connection_Prefix.pch;
 				HEADER_SEARCH_PATHS = "\"$(SOURCE_ROOT)/CURLHandle/SFTP/libssh2/include\"";
 				INFOPLIST_FILE = "Resources/Framework-Info.plist";
-				INSTALL_PATH = "@rpath";
+				INSTALL_PATH = "@loader_path/../Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
For most modern projects @loader_path is the preferred way of referencing a bundled framework.
