### PR TITLE
Handle -ck2_displayName returning nil

### DIFF
--- a/ConnectionKit/CK2PathControl.m
+++ b/ConnectionKit/CK2PathControl.m
@@ -92,13 +92,10 @@
                 image = [[[tempURL ck2_icon] copy] autorelease];
                 title = [tempURL ck2_displayName];
                 
-                if ([title isEqual:@"/"])
+                if ([title isEqual:@"/"] ||
+                    title.length == 0)      // happens for URLs like ftpes://user@example.com
                 {
                     title = [tempURL host];
-                }
-                else if (title == nil)   // happens for URLs like ftpes://user@example.com
-                {
-                    title = @"";
                 }
                 
                 item = [[NSMenuItem alloc] initWithTitle:title action:@selector(urlSelected:) keyEquivalent:@""];

--- a/ConnectionKit/CK2PathControl.m
+++ b/ConnectionKit/CK2PathControl.m
@@ -96,6 +96,10 @@
                 {
                     title = [tempURL host];
                 }
+                else if (title == nil)   // happens for URLs like ftpes://user@example.com
+                {
+                    title = @"";
+                }
                 
                 item = [[NSMenuItem alloc] initWithTitle:title action:@selector(urlSelected:) keyEquivalent:@""];
                 [item setTarget:self];


### PR DESCRIPTION
It seems for some URLs, at least on 10.9, -getResourceValue:… returns YES and reports the display name as nil. We now treat that as an empty string so menu logic doesn't crash. The downside is you see a nameless folder in the path control.
