### PR TITLE
Stop trying to fill in user name for directory listings

### DIFF
--- a/ConnectionKit/CK2CURLBasedProtocol.m
+++ b/ConnectionKit/CK2CURLBasedProtocol.m
@@ -335,7 +335,7 @@
         else
         {
             // Correct relative paths if we can
-            NSURL *directoryURL = [self.class URLByReplacingUserInfoInURL:request.URL withUser:_user];
+            NSURL *directoryURL = request.URL;
             NSString *directoryPath = [self.class pathOfURLRelativeToHomeDirectory:directoryURL];
 
             NSURL *home = [self.class homeDirectoryURLForServerAtURL:directoryURL];

--- a/ConnectionKit/CK2FileManager.h
+++ b/ConnectionKit/CK2FileManager.h
@@ -80,6 +80,10 @@ typedef NS_OPTIONS(NSInteger, CK2DirectoryEnumerationOptions) {
  The order of the files in the returned array generally follows that returned by the server, which is likely undefined.
  
  Paths are standardized if possible (i.e. case is corrected if needed, and relative paths resolved).
+ Any user info you pass in as part of `url` (username or password) will be included back in returned
+ URLs. Note that if you use the authentication callback to specify a user different to the one in
+ `url`, the results you get back won't reflect that change in user; it becomes your responsibility
+ to adjust the resultant URLs if your app needs it.
  
  Many protocols provide a decent error code indicating *why* the operation
  failed. Unfortunately, FTP cannot. The FTP spec means the only machine-readable

--- a/ConnectionKit/CK2Protocol.h
+++ b/ConnectionKit/CK2Protocol.h
@@ -111,8 +111,6 @@
 /**
  Replaces the user info portion of `aURL` (i.e. the username and password) with a single desired
  username.
- 
- Handy for subclasses to make sure the URLs they vend out refer to the correct user.
  */
 + (NSURL *)URLByReplacingUserInfoInURL:(NSURL *)aURL withUser:(NSString *)nsUser;
 

--- a/ConnectionKit/CK2WebDAVProtocol.h
+++ b/ConnectionKit/CK2WebDAVProtocol.h
@@ -17,7 +17,6 @@ typedef void (^CK2WebDAVErrorHandler)(NSError* error);
     DAVSession*         _session;
     NSOperationQueue*   _queue;
 
-    NSString    *_user;
     CK2WebDAVCompletionHandler _completionHandler;
     CK2WebDAVErrorHandler _errorHandler;
     

--- a/ConnectionKit/CK2WebDAVProtocol.m
+++ b/ConnectionKit/CK2WebDAVProtocol.m
@@ -51,7 +51,6 @@
     [_errorHandler release];
     [_queue release];
     [_session release];
-    [_user release];
 
     [super dealloc];
 }
@@ -97,7 +96,6 @@
 
                     NSURL* url = [[davRequest concatenatedURLWithPath:[item href]] absoluteURL];
                     NSAssert(url, @"-concatenatedURLWithPath: returned nil URL. Shouldn't happen unless davRequest has no URL, and that shouldn't ever happen!");
-                    url = [self.class URLByReplacingUserInfoInURL:url withUser:_user];
                     
                     [CK2FileManager setTemporaryResourceValue:[item modificationDate] forKey:NSURLContentModificationDateKey inURL:url];
                     [CK2FileManager setTemporaryResourceValue:[item creationDate] forKey:NSURLCreationDateKey inURL:url];
@@ -391,15 +389,6 @@
     CK2WebDAVLog(@"webdav received challenge");
     
     [self.client protocol:self didReceiveChallenge:challenge completionHandler:^(CK2AuthChallengeDisposition disposition, NSURLCredential *credential) {
-        
-        if (disposition == CK2AuthChallengeUseCredential)
-        {
-            NSString *user = credential.user;
-            if (user)
-            {
-                [_user release]; _user = [user copy];
-            }
-        }
         
         completionHandler(disposition, credential);
     }];


### PR DESCRIPTION
Instead, the username passed in in the original URL is respected. Any
smarts needed beyond that are the client’s responsibility.
As discussed in issue #79
