### PR TITLE
Make CK2FileOperation.originalURL public

### DIFF
--- a/ConnectionKit/CK2FileOperation.h
+++ b/ConnectionKit/CK2FileOperation.h
@@ -46,6 +46,21 @@ typedef NS_ENUM(NSInteger, CK2FileOperationState) {
 }
 
 /**
+ @return a deep copy of the original connection request.
+ 
+ You can think of this as the "primary" URL for a given operation. Normally this is fairly obvious:
+ if uploading, it's the URL being uploaded to. When we come to support downloads, it's the URL being
+ downloaded from.
+ 
+ This can potentially get a bit tricky doing something like renaming/moving a file; in which case,
+ this URL will be that of the _source_ file.
+ 
+ ConnectionKit doesn't currently support redirects, but were it to, this URL would remain constant
+ and we'd likely introduce a new `currentURL` property for retrieving the redirected URL if need be.
+ */
+@property (readonly, copy) NSURL *originalURL;
+
+/**
  * Number of body bytes already written.
  *
  * Excludes any headers, such as in HTTP messages, or FTP control connection.

--- a/ConnectionKit/CK2FileOperation.h
+++ b/ConnectionKit/CK2FileOperation.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, CK2FileOperationState) {
 {
   @private
     CK2FileManager  *_manager;
-    NSURL           *_URL;
+    NSURL           *_originalURL;
     NSString        *_descriptionForErrors;
     dispatch_queue_t    _queue;
     

--- a/ConnectionKit/CK2FileOperation.m
+++ b/ConnectionKit/CK2FileOperation.m
@@ -14,7 +14,6 @@
 
 @interface CK2FileOperation () <CK2ProtocolClient>
 @property(readonly) CK2FileManager *fileManager;    // goes to nil once finished/failed
-@property(readonly) NSURL *originalURL;
 @property (readwrite) int64_t countOfBytesWritten;
 @property (readwrite) int64_t countOfBytesExpectedToWrite;
 @property(readwrite) CK2FileOperationState state;

--- a/ConnectionKit/CK2FileOperation.m
+++ b/ConnectionKit/CK2FileOperation.m
@@ -55,7 +55,7 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
     {
         _state = CK2FileOperationStateSuspended;
         _manager = [manager retain];
-        _URL = [url copy];
+        _originalURL = [url copy];
         _descriptionForErrors = [errorDescription copy];
         
         if (!completionBlock)
@@ -306,7 +306,7 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
 {
     //[_protocol release];  DON'T release protocol. It should be a weak reference by the time deallocation happens
     [_manager release];
-    [_URL release];
+    [_originalURL release];
     if (_queue) dispatch_release(_queue);
     [_completionBlock release];
     [_enumerationBlock release];
@@ -342,7 +342,7 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
 
 #pragma mark URL & Requests
 
-@synthesize originalURL = _URL;
+@synthesize originalURL = _originalURL;
 
 - (NSURLRequest *)requestWithURL:(NSURL *)url;
 {

--- a/ConnectionKit/CKUploader.m
+++ b/ConnectionKit/CKUploader.m
@@ -13,11 +13,6 @@
 #import <CURLHandle/CURLHandle.h>
 
 
-@interface CK2FileOperation (SecretsIKnow)
-- (NSURL *)originalURL;
-@end
-
-
 @implementation CKUploader
 
 #pragma mark Lifecycle


### PR DESCRIPTION
After prolonged internal agony, I think this API makes sense, particularly within the docs I've given it. It allows us to simplify the uploader slightly, and there will be other improvements from there.
