### PR TITLE
Fix warnings

### DIFF
--- a/ConnectionKit/CK2FileCell.m
+++ b/ConnectionKit/CK2FileCell.m
@@ -125,23 +125,14 @@
     if (!_isTextOnly)
     {
         NSRect imageRect = [self imageRectForBounds:cellFrame];
-        if (self.image) {
-            // Flip images that don't agree with our flipped state
-            BOOL flipped = [controlView isFlipped] != [self.image isFlipped];
-            if (flipped) {
-                [[NSGraphicsContext currentContext] saveGraphicsState];
-                NSAffineTransform *transform = [[NSAffineTransform alloc] init];
-                [transform translateXBy:0 yBy:cellFrame.origin.y + cellFrame.size.height];
-                [transform scaleXBy:1.0 yBy:-1.0];
-                [transform translateXBy:0 yBy:-cellFrame.origin.y];
-                [transform concat];
-                [transform release];
-            }
-            [self.image drawInRect:imageRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
-            if (flipped) {
-                [[NSGraphicsContext currentContext] restoreGraphicsState];
-            }
-        }
+        
+        [self.image drawInRect:imageRect
+                      fromRect:NSZeroRect
+                     operation:NSCompositeSourceOver
+                      fraction:1.0
+                respectFlipped:YES
+                         hints:nil];
+        
         CGFloat inset = (ICON_INSET_HORIZ + ICON_SIZE + ICON_TEXT_SPACING);
         cellFrame.origin.x += inset;
         cellFrame.size.width -= inset;

--- a/ConnectionKit/CKTransferProgressCell.m
+++ b/ConnectionKit/CKTransferProgressCell.m
@@ -115,11 +115,13 @@ NSSize CKLimitMaxWidthHeight(NSSize ofSize, CGFloat toMaxDimension);
 									 NSMidY(imageRect) - (s.height / 2),
 									 s.width,
 									 s.height);
-		[sErrorImage setFlipped:[controlView isFlipped]];
-		[sErrorImage drawInRect:centered
+
+        [sErrorImage drawInRect:centered
 					   fromRect:NSZeroRect
 					  operation:NSCompositeSourceOver
-					   fraction:1.0];
+					   fraction:1.0
+                 respectFlipped:YES
+                          hints:nil];
 	}
 	else if (myProgress >= 0 && !_finished)
 	{
@@ -181,11 +183,13 @@ NSSize CKLimitMaxWidthHeight(NSSize ofSize, CGFloat toMaxDimension);
 									 NSMidY(imageRect) - (s.height / 2),
 									 s.width,
 									 s.height);
-		[sFinishedImage setFlipped:[controlView isFlipped]];
+        
 		[sFinishedImage drawInRect:centered
 						  fromRect:NSZeroRect
 						 operation:NSCompositeSourceOver
-						  fraction:1.0];
+						  fraction:1.0
+                    respectFlipped:YES
+                             hints:nil];
 	}
 }
 


### PR DESCRIPTION
This switches to the modern image drawing routines introduced in 10.6 so as to avoid directly mucking with image flippedness. @MrNoodle anything else you think I should look at?
