### PR TITLE
Properly escape command to fix a bug preventing creation of folders with a space in the name

### DIFF
--- a/ConnectionKit/CK2SFTPProtocol.m
+++ b/ConnectionKit/CK2SFTPProtocol.m
@@ -70,7 +70,7 @@
 
     NSString* path = [self.class pathOfURLRelativeToHomeDirectory:[request URL]];
 
-    NSString* command = [@"mkdir " stringByAppendingString:path];
+    NSString* command = [@"mkdir " stringByAppendingFormat:@"\"%@\"",path];
     self = [self initWithCustomCommands:[NSArray arrayWithObject:command]
                                 request:mutableRequest
           createIntermediateDirectories:createIntermediates


### PR DESCRIPTION
Properly escape command to fix a bug preventing creation of folders with a space in the name
