### PR TITLE
One CURL session (multi handle) per CK2FileManager

### DIFF
--- a/Connection.xcodeproj/project.pbxproj
+++ b/Connection.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		27999BB7170B4BA200A54BEE /* CK2FileManagerWithTestSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 228E180E1700AEA300ACDE94 /* CK2FileManagerWithTestSupport.m */; };
 		27A2072B1671634800D8284D /* CK2CURLBasedProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 27A207291671634800D8284D /* CK2CURLBasedProtocol.h */; };
 		27A2072C1671634800D8284D /* CK2CURLBasedProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A2072A1671634800D8284D /* CK2CURLBasedProtocol.m */; };
+		27ADC5771AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 27ADC5751AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.h */; };
+		27ADC5781AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 27ADC5761AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.m */; };
 		27CFEC7218E73526007158A4 /* URLs.testdata in Resources */ = {isa = PBXBuildFile; fileRef = 27CFEC7118E73526007158A4 /* URLs.testdata */; };
 		27D03B421471787000FEA588 /* CKUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 27D03B401471787000FEA588 /* CKUploader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27D03B431471787000FEA588 /* CKUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 27D03B411471787000FEA588 /* CKUploader.m */; };
@@ -363,6 +365,8 @@
 		27993E8316FCB30D008DC1B0 /* CK2FileOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CK2FileOperation.m; sourceTree = "<group>"; };
 		27A207291671634800D8284D /* CK2CURLBasedProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CK2CURLBasedProtocol.h; sourceTree = "<group>"; };
 		27A2072A1671634800D8284D /* CK2CURLBasedProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CK2CURLBasedProtocol.m; sourceTree = "<group>"; };
+		27ADC5751AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CK2CurlTransferStackManager.h; sourceTree = "<group>"; };
+		27ADC5761AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CK2CurlTransferStackManager.m; sourceTree = "<group>"; };
 		27BFFEDA15027F4100EFA319 /* CURLHandle.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CURLHandle.xcodeproj; path = ../CurlHandle/CURLHandleSource/CURLHandle.xcodeproj; sourceTree = "<group>"; };
 		27CFEC7118E73526007158A4 /* URLs.testdata */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = URLs.testdata; sourceTree = "<group>"; };
 		27D03B401471787000FEA588 /* CKUploader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CKUploader.h; path = ConnectionKit/CKUploader.h; sourceTree = "<group>"; };
@@ -733,6 +737,8 @@
 				2790A8281627636E000C9D9F /* CK2Protocol.m */,
 				27A207291671634800D8284D /* CK2CURLBasedProtocol.h */,
 				27A2072A1671634800D8284D /* CK2CURLBasedProtocol.m */,
+				27ADC5751AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.h */,
+				27ADC5761AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.m */,
 				2790A94616278F1D000C9D9F /* CK2FTPProtocol.h */,
 				2790A94716278F1D000C9D9F /* CK2FTPProtocol.m */,
 				27F394F3162C162900944F43 /* CK2SFTPProtocol.h */,
@@ -999,6 +1005,7 @@
 				2743E8091622E47600019979 /* CK2FileManager.h in Headers */,
 				2790A8291627636E000C9D9F /* CK2Protocol.h in Headers */,
 				2790A94816278F1D000C9D9F /* CK2FTPProtocol.h in Headers */,
+				27ADC5771AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.h in Headers */,
 				27F394F5162C162900944F43 /* CK2SFTPProtocol.h in Headers */,
 				27431CA01630381D00F6FB58 /* CK2FileProtocol.h in Headers */,
 				27A2072B1671634800D8284D /* CK2CURLBasedProtocol.h in Headers */,
@@ -1225,7 +1232,8 @@
 		279117E1178B5A86006BF857 /* CURLHandleTests.octest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = CURLHandleTests.octest;
+			name = CURLHandleTests.octest;
+			path = CURLHandleTests.xctest;
 			remoteRef = 279117E0178B5A86006BF857 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1425,6 +1433,7 @@
 				798313CA0B0D67E000F5078E /* CKTransferProgressCell.m in Sources */,
 				27D03B431471787000FEA588 /* CKUploader.m in Sources */,
 				2743E80A1622E47600019979 /* CK2FileManager.m in Sources */,
+				27ADC5781AC0CD7D0085C7F7 /* CK2CurlTransferStackManager.m in Sources */,
 				2790A82A1627636E000C9D9F /* CK2Protocol.m in Sources */,
 				2790A94916278F1D000C9D9F /* CK2FTPProtocol.m in Sources */,
 				27F394F6162C162900944F43 /* CK2SFTPProtocol.m in Sources */,

--- a/ConnectionKit/CK2CurlTransferStackManager.h
+++ b/ConnectionKit/CK2CurlTransferStackManager.h
@@ -11,7 +11,7 @@
 
 /**
  This is a little wrapper around a CURLTransferStack. We use it to tie each CK2FileManager to a
- transfer stack, and invalidate that stack down when appropriate.
+ transfer stack, and invalidate that stack when appropriate.
  */
 @interface CK2CurlTransferStackManager : NSObject {
     CURLTransferStack   *_transferStack;

--- a/ConnectionKit/CK2CurlTransferStackManager.h
+++ b/ConnectionKit/CK2CurlTransferStackManager.h
@@ -1,0 +1,25 @@
+//
+//  CK2CurlTransferStackManager.h
+//  Connection
+//
+//  Created by Mike on 23/03/2015.
+//
+//
+
+#import <CURLHandle/CURLHandle.h>
+
+
+/**
+ This is a little wrapper around a CURLTransferStack. We use it to tie each CK2FileManager to a
+ transfer stack, and invalidate that stack down when appropriate.
+ */
+@interface CK2CurlTransferStackManager : NSObject {
+    CURLTransferStack   *_transferStack;
+}
+
+/**
+ The manager automatically creates a transfer stack for itself
+ */
+@property(nonatomic, readonly) CURLTransferStack *transferStack;
+
+@end

--- a/ConnectionKit/CK2CurlTransferStackManager.m
+++ b/ConnectionKit/CK2CurlTransferStackManager.m
@@ -1,0 +1,30 @@
+//
+//  CK2CurlTransferStackManager.m
+//  Connection
+//
+//  Created by Mike on 23/03/2015.
+//
+//
+
+#import "CK2CurlTransferStackManager.h"
+
+@implementation CK2CurlTransferStackManager
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _transferStack = [CURLTransferStack transferStackWithDelegate:nil delegateQueue:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    // We're being torn down, so figure now is the time to invalidate transfer stack. Crude, but
+    // there you go.
+    [self.transferStack finishTransfersAndInvalidate];
+    
+    [super dealloc];
+}
+
+@synthesize transferStack = _transferStack;
+
+@end

--- a/ConnectionKit/CK2FileManager.m
+++ b/ConnectionKit/CK2FileManager.m
@@ -113,6 +113,12 @@ NSString * const CK2URLSymbolicLinkDestinationKey = @"CK2URLSymbolicLinkDestinat
     return [self initWithDelegate:nil delegateQueue:nil];
 }
 
+- (void)dealloc {
+    [_delegateQueue release];
+    
+    [super dealloc];
+}
+
 #pragma mark Discovering Directory Contents
 
 - (CK2FileOperation *)contentsOfDirectoryAtURL:(NSURL *)url

--- a/ConnectionKit/CK2FileManagerWithTestSupport.h
+++ b/ConnectionKit/CK2FileManagerWithTestSupport.h
@@ -4,7 +4,7 @@
 
 #import "CK2FileManager.h"
 
-@class CURLMultiHandle;
+@class CURLTransferStack;
 
 /**
  CK2FileManager with some additional API for test purposes.
@@ -13,7 +13,7 @@
 @interface CK2FileManagerWithTestSupport : CK2FileManager
 {
     BOOL _dontShareConnections;
-    CURLMultiHandle* _multi;
+    CURLTransferStack* _multi;
 }
 
 /**
@@ -21,7 +21,7 @@
  This is generated on demand, if dontShareConnections is set.
  */
 
-@property (strong, readonly, nonatomic) CURLMultiHandle* multi;
+@property (strong, readonly, nonatomic) CURLTransferStack* multi;
 
 /**
  Set this property to force CURL based protocols use an alternative CURLTransfer instead of the default one
@@ -32,10 +32,10 @@
 @end
 
 @interface NSURLRequest(CK2FileManagerDebugging)
-- (CURLMultiHandle*)ck2_multi;
+- (CURLTransferStack*)ck2_multi;
 @end
 
 @interface NSMutableURLRequest(CK2FileManagerDebugging)
-- (void)ck2_setMulti:(CURLMultiHandle*)multi;
+- (void)ck2_setMulti:(CURLTransferStack*)multi;
 @end
 

--- a/ConnectionKit/CK2FileManagerWithTestSupport.m
+++ b/ConnectionKit/CK2FileManagerWithTestSupport.m
@@ -9,8 +9,8 @@
 
 
 @interface CURLTransfer (Testing)
-+ (void)cleanupStandaloneMulti:(CURLMultiHandle *)multi;
-+ (CURLMultiHandle *)standaloneMultiForTestPurposes;
++ (void)cleanupStandaloneMulti:(CURLTransferStack *)multi;
++ (CURLTransferStack *)standaloneMultiForTestPurposes;
 @end
 
 
@@ -32,7 +32,7 @@
     return [CK2FileOperationWithTestSupport class];
 }
 
-- (CURLMultiHandle*)multi
+- (CURLTransferStack*)multi
 {
     if (_dontShareConnections && !_multi)
     {
@@ -46,7 +46,7 @@
 
 @implementation NSURLRequest(CK2FileManagerDebugging)
 
-- (CURLMultiHandle*)ck2_multi
+- (CURLTransferStack*)ck2_multi
 {
     return [NSURLProtocol propertyForKey:@"ck2_multi" inRequest:self];
 }
@@ -54,7 +54,7 @@
 @end
 @implementation NSMutableURLRequest(CK2FileManagerDebugging)
 
-- (void)ck2_setMulti:(CURLMultiHandle*)multi
+- (void)ck2_setMulti:(CURLTransferStack*)multi
 {
     [NSURLProtocol setProperty:multi forKey:@"ck2_multi" inRequest:self];
 }

--- a/ConnectionKit/CK2FileOperation.m
+++ b/ConnectionKit/CK2FileOperation.m
@@ -425,6 +425,10 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
                     NSAssert(_protocol == nil, @"Protocol has already been created");
                     _protocol = _createProtocolBlock(protocolClass);
                     
+                    // Protocol creation block was probably creating a retain cycle back to self, so
+                    // dispose of now we've used it
+                    [_createProtocolBlock release]; _createProtocolBlock = nil;
+                    
                     if (!_protocol)
                     {
                         // it's likely that the protocol has already called protocol:didFailWithError:, which will have called finishWithError:, which means that a call to the completion

--- a/ConnectionKit/CK2FileOperation.m
+++ b/ConnectionKit/CK2FileOperation.m
@@ -310,6 +310,8 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
             }];
             
             [_completionBlock release]; _completionBlock = nil;
+            [_progressBlock release];   _progressBlock = nil;
+            [_enumerationBlock release];_enumerationBlock = nil;
             
             
             // Break retain cycle, but deliberately keep weak reference so we know we're associated with it

--- a/ConnectionKit/CK2FileOperation.m
+++ b/ConnectionKit/CK2FileOperation.m
@@ -303,7 +303,7 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
             // Make all notifications — including KVO — happen on the delegate queue
             void (^block)(NSError*) = _completionBlock;
             
-            [self tryToMessageDelegateSelector:NULL usingBlock:^(id<CK2FileManagerDelegate> delegate) {
+            [self tryToMessageDelegateSelector:NULL usingBlock:^(id<CK2FileManagerDelegate> delegate) { // NULL selector so always executes
                 self.error = error;
                 self.state = CK2FileOperationStateCompleted;
                 block(error);


### PR DESCRIPTION
Up until now, all `CK2FileManager` instances have shared a single global Curl multi handle, and so have all shared the same connection cache. The trouble is a scenario like so:
1. Connect to FTP server and do some work
2. Chunk of time elapses (I think at least 5 or 10 minutes)
3. Ask to do more FTP work to the same server

We find that the FTP server has quietly shut down our connection (or maybe a router elsewhere on the internet has, don't really know) due to the time elapsed. At least for some connections, libcurl is blissfully unaware of this. So at step 3, it tries to re-use the connection and just sits there until timeout, waiting for something to come back from the server.

This pull changes the contract a bit so that it's up to client apps how they want to manage connection re-use. If you do want to re-use connections, simply do all work with the same `CK2FileManager` instance. If you want fresh connections, fire up a fresh file manager and use that.

WebDAV/HTTP connections still use a global connection cache I believe, because we don't really have control over that. But the OS seems to be able to handle this properly. At some point we'll move to using `NSURLSession` internally, and then will get control over connection re-use, much like the curl-based stuff.
