### PR TITLE
Actually record that SFTP directory creation wants intermediate directories to be created

### DIFF
--- a/ConnectionKit/CK2FileOperation.m
+++ b/ConnectionKit/CK2FileOperation.m
@@ -120,7 +120,7 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
     NSString *description = [NSString stringWithFormat:NSLocalizedString(@"The folder “%@” could not be created.", "error descrption"),
                              url.lastPathComponent];
     
-    return [self initWithURL:url errorDescription:description manager:manager completionHandler:block createProtocolBlock:^CK2Protocol *(Class protocolClass) {
+    self = [self initWithURL:url errorDescription:description manager:manager completionHandler:block createProtocolBlock:^CK2Protocol *(Class protocolClass) {
         
         return [[protocolClass alloc] initForCreatingDirectoryWithRequest:[self requestWithURL:url]
                                               withIntermediateDirectories:createIntermediates
@@ -132,6 +132,8 @@ createProtocolBlock:(CK2Protocol *(^)(Class protocolClass))createBlock;
     if ([url.scheme caseInsensitiveCompare:@"sftp"] == NSOrderedSame) {
         _createIntermediateDirectories = createIntermediates;
     }
+    
+    return self;
 }
 
 - (id)initFileCreationOperationWithURL:(NSURL *)url


### PR DESCRIPTION
This fixes problem where only a missing parent directory of a file was being created. All other cases, such as creating a directory, or needing to create deeper ancestral directories were failing.
