### PR TITLE
Safer check of enumeration block

### DIFF
--- a/ConnectionKit/CK2FileOperation.m
+++ b/ConnectionKit/CK2FileOperation.m
@@ -659,12 +659,10 @@ callbacks:(CK2FileOperationCallbacks *)callbacks;
     // Provide ancestry and other fairly generic keys on-demand
     [self.class setResourceValueBlocksForURL:url protocolClass:protocol.class];
     
-    if (_enumerationBlock)
-    {
+    
         [self tryToMessageDelegateSelector:NULL usingBlock:^(id<CK2FileManagerDelegate> delegate) {
-            _enumerationBlock(url);
+            if (_enumerationBlock) _enumerationBlock(url);
         }];
-    }
     
     // It seems poor security to vend out passwords here, so have a quick sanity check
     if (CFURLGetByteRangeForComponent((CFURLRef)url, kCFURLComponentPassword, NULL).location != kCFNotFound)


### PR DESCRIPTION
Avoids a race condition where if the operation is cancelled, the
enumeration block could be NULL by the time it’s used
